### PR TITLE
Change format to fix multiline progress bar printing

### DIFF
--- a/chapter_split/ffmpeg.py
+++ b/chapter_split/ffmpeg.py
@@ -134,7 +134,7 @@ def run_ffmpeg(
                             )
                             bar.set_percent(percentage)
                             percentmsg.set_value(
-                                " ({: 3d}%)".format(percentage)
+                                " ({:3d}%)".format(percentage)
                             )
                             sys.stdout.write("{}\r".format(line))
                             break


### PR DESCRIPTION
Fix progress bar printing such as:
```
Chapter  8/14 [########-------]: Progress [################] ( 100%
Chapter 14/14 [###############]: Progress [################] (100%)
```
Closing #1 